### PR TITLE
Add bucket region option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Download the source code, dependencies and test dependencies:
     - `MAX_NO_OF_GOROUTINES` the maximum number of goroutines which is used to zip files
     - `YEAR_TO_START` the app will create yearly zips starting from provided year. Defaults to 1995, when the first FT article has been published. 
     - `BUCKET_NAME` bucket name of content
+    - `BUCKET_REGION` bucket-name's region
     - `S3_DOMAIN` S3 domain of content
     - `S3_CONTENT_FOLDER` name of the folder that json files with the content are stored in
     - `S3_CONCEPT_FOLDER` name of the folder that json files with the concept are stored in

--- a/helm/zipper-s3/templates/job.yaml
+++ b/helm/zipper-s3/templates/job.yaml
@@ -36,6 +36,11 @@ spec:
                 configMapKeyRef:
                   name: global-config
                   key: upp-exports-s3.bucket
+            - name: BUCKET_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: global-config
+                  key: upp-exports-s3.region
             - name: S3_CONCEPT_FOLDER
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
# Description

The service might be deployed in one region, but to be accessing bucket in another.

## Why

The service wasn't working on our US clusters because it was trying to access bucket in eu-west-1, but by default an aws session for us-east-1 region was created. 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
