### PR TITLE
Changed CronJob schedule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,5 +25,16 @@ _Is there a better library for doing x_
 - [ ] Breaking change
 - [ ] Minor change (e.g. fixing a typo, adding config)
 
+## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"
+
+- [ ] Test coverage is not significantly decreased
+- [ ] All PR checks have passed
+- [ ] Changes are deployed on dev before asking for review
+- [ ] Documentations remains up-to-date
+  - [ ] OpenAPI definition file is updated
+  - [ ] README file is updated
+  - [ ] Documentation is updated in upp-docs and upp-public-docs
+  - [ ] Architecture diagrams are updated
+
 ___
 This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)

--- a/helm/zipper-s3/templates/job.yaml
+++ b/helm/zipper-s3/templates/job.yaml
@@ -8,7 +8,7 @@ metadata:
     visualize: "true"
     app: {{ .Values.job.name }}
 spec:
-  schedule: "0 4 * * *"
+  schedule: "0 5 * * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:


### PR DESCRIPTION
# Description

## What

Changed CronJob start time from 04:00 to 05:00 because of a large number of articles scheduled to be published at 04:00. This leads to missing articles in the created archive.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-4478)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
